### PR TITLE
Avoid defining eTeX primitives in LuaTeX

### DIFF
--- a/iftex.sty
+++ b/iftex.sty
@@ -54,19 +54,18 @@
 }
 
 
-% make sure \detokenize and \protected are available in lualatex,
-% but avoid defining them after the package if not already defined.
-\ifx\directlua\@undefined\else
-  \let\IFTEX@detokenize\detokenize
-  \let\IFTEX@protected\protected
-  \directlua{tex.enableprimitives("", {"detokenize","protected"})}
-\fi
-
 % eTeX \protected if available.
 \ifx\protected\@undefined
   \let\IFTEX@protected\relax
 \else
   \let\IFTEX@protected\protected
+\fi
+
+
+% make sure \detokenize and \protected are available in lualatex,
+% but avoid defining them after the package if not already defined.
+\ifx\directlua\@undefined\else
+  \directlua{tex.enableprimitives("IFTEX@", {"detokenize","protected"})}
 \fi
 
 
@@ -134,7 +133,7 @@
 \IFTEX@let{luahbtex}{false}
 \ifx\directlua\@undefined
 \else
-  \directlua{\detokenize{
+  \directlua{\IFTEX@detokenize{
    if(pcall(require, 'luaharfbuzz')) then
      tex.print("\\let\\ifluahbtex\\iftrue ")
    end
@@ -216,7 +215,7 @@
   \fi
 \fi
 \else
-\directlua{\detokenize{
+\directlua{\IFTEX@detokenize{
 if (tex.outputmode or tex.pdfoutput or 0) > 0 then
   tex.print('\\pdftrue')
 end
@@ -224,8 +223,4 @@ end
 \fi
 
 % restore things
-\ifx\directlua\@undefined\else
-  \let\detokenize\IFTEX@detokenize
-  \let\protected\IFTEX@protected
-\fi
 \catcode64 \IFTEX@atcatcode


### PR DESCRIPTION
Use a `IFTEX@` prefix for primitives in LuaTeX instead of manually restoring the value.

Fixes problems when the package is loaded locally and double-use of `\IFTEX@protected`.