### PR TITLE
Added TexpadTeX cases

### DIFF
--- a/iftex.sty
+++ b/iftex.sty
@@ -88,7 +88,9 @@
 \IFTEX@protected\def\RequireAlephTeX{\IFTEX@Require\ifalephtex{Aleph}\fi}
 % tutex == has \Umathchardef == XeTeX or Lua(HB)TeX currently
 \IFTEX@protected\def\RequireTUTeX{\IFTEX@Require\iftutex{LuaTeX or XeTeX}\fi}
-
+\IFTEX@protected\def\RequireTexpadTeX{\IFTEX@Require\iftexpadtex{TexpadTeX}\fi}
+\IFTEX@protected\def\RequireTexpadTeXUnicode{\IFTEX@Require\iftexpadtexunicode{TexpadTeXUnicode}\fi}
+\IFTEX@protected\def\RequireTexpadTeXEightBit{\IFTEX@Require\iftexpadtexeightbit{TexpadTeXEightBit}\fi}
 
 % As a matter of policy over-write any existing \if*tex macro and set
 % by the tests here.
@@ -210,7 +212,27 @@
 \fi
 \IFTEX@let{TUTeX}{tutex}
 
-% Output mode 
+% texpadtex
+\begingroup\expandafter\expandafter\expandafter\endgroup
+\expandafter\ifx\csname TexpadTeXMode\endcsname\relax
+  \IFTEX@let{texpadtex}{false}
+  \IFTEX@let{texpadtexunicode}{false}
+  \IFTEX@let{texpadtexeightbit}{false}
+\else
+  \IFTEX@let{texpadtex}{true}
+  \ifcase\TexpadTeXMode\relax
+    \IFTEX@let{texpadtexunicode}{false}
+    \IFTEX@let{texpadtexeightbit}{true}
+  \or
+    \IFTEX@let{texpadtexunicode}{true}
+    \IFTEX@let{texpadtexeightbit}{false}
+  \fi
+\fi
+\IFTEX@let{TexpadTeX}{texpadtex}
+\IFTEX@let{TexpadTeXUnicode}{texpadtexunicode}
+\IFTEX@let{TexpadTeXEightBit}{texpadtexeightbit}
+
+% Output mode
 % declare as if with \newif
 \def\pdftrue{\let\ifpdf\iftrue}
 \def\pdffalse{\let\ifpdf\iffalse}
@@ -226,6 +248,10 @@ end
 \expandafter\ifx\csname pdfoutput\endcsname\relax
 \ifvtex
   \ifnum\OpMode=3 %
+    \pdftrue
+  \fi
+\else
+  \iftexpadtex
     \pdftrue
   \fi
 \fi

--- a/iftex.sty
+++ b/iftex.sty
@@ -89,8 +89,6 @@
 % tutex == has \Umathchardef == XeTeX or Lua(HB)TeX currently
 \IFTEX@protected\def\RequireTUTeX{\IFTEX@Require\iftutex{LuaTeX or XeTeX}\fi}
 \IFTEX@protected\def\RequireTexpadTeX{\IFTEX@Require\iftexpadtex{TexpadTeX}\fi}
-\IFTEX@protected\def\RequireTexpadTeXUnicode{\IFTEX@Require\iftexpadtexunicode{TexpadTeXUnicode}\fi}
-\IFTEX@protected\def\RequireTexpadTeXEightBit{\IFTEX@Require\iftexpadtexeightbit{TexpadTeXEightBit}\fi}
 
 % As a matter of policy over-write any existing \if*tex macro and set
 % by the tests here.
@@ -216,21 +214,15 @@
 \begingroup\expandafter\expandafter\expandafter\endgroup
 \expandafter\ifx\csname TexpadTeXMode\endcsname\relax
   \IFTEX@let{texpadtex}{false}
-  \IFTEX@let{texpadtexunicode}{false}
-  \IFTEX@let{texpadtexeightbit}{false}
 \else
   \IFTEX@let{texpadtex}{true}
   \ifcase\TexpadTeXMode\relax
-    \IFTEX@let{texpadtexunicode}{false}
-    \IFTEX@let{texpadtexeightbit}{true}
+    % This is 8 bit mode
   \or
-    \IFTEX@let{texpadtexunicode}{true}
-    \IFTEX@let{texpadtexeightbit}{false}
+    \IFTEX@let{tutex}{true}
   \fi
 \fi
 \IFTEX@let{TexpadTeX}{texpadtex}
-\IFTEX@let{TexpadTeXUnicode}{texpadtexunicode}
-\IFTEX@let{TexpadTeXEightBit}{texpadtexeightbit}
 
 % Output mode
 % declare as if with \newif

--- a/iftex.tex
+++ b/iftex.tex
@@ -119,6 +119,27 @@ true for Lua\TeX\ and Xe\TeX, allowing constructs such as
   \usepackage{newtxtext,newtxmath}
 \fi
 \end{verbatim}
+\item[\cs{iftexpadtex}, \cs{ifTexpadTeX}]
+True if Texpad\TeX\ is in use. Please note that Texpad\TeX\ can run in two
+modes, one which uses Unicode and native fonts internally (similar to
+Xe\TeX\ and Lua\TeX), and one which uses 8-bit codepages internally (similar to
+PDF\TeX). These modes can be further distinguished with
+\cs{iftexpadtexunicode} and \cs{iftexpadtexeightbit} respectively, allowing for
+constructs such as
+\begin{verbatim}
+\iftexpadtexunicode
+  \usepackage{fontspec}
+  \setmainfont{Times}
+\else
+  \usepackage{times}
+\fi
+\end{verbatim}
+\begin{description}
+\item[\cs{iftexpadtexunicode}, \cs{ifTexpadTeXUnicode}]
+True if Texpad\TeX\ is running in Unicode mode.
+\item[\cs{iftexpadtexeightbit}, \cs{ifTexpadTeXEightBit}]
+True if Texpad\TeX\ is running in 8-bit mode.
+\end{description}
 
 \end{description}
 
@@ -139,6 +160,9 @@ with a suitable engine, and stops with an error message if not.
 \item[\cs{RequireVTeX}]
 \item[\cs{RequireAlephTeX}]
 \item[\cs{RequireTUTeX}]
+\item[\cs{RequireTexpadTeX}]
+\item[\cs{RequireTexpadTeXUnicode}]
+\item[\cs{RequireTexpadTeXEightBit}]
 \end{description}
 
 

--- a/iftex.tex
+++ b/iftex.tex
@@ -22,7 +22,7 @@
 
 \section{Introduction}
 This original \textsf{iftex} was written as part of the \textsf{bidi}
-collection (by the Persian TeX Group / Vafa Khalighi) 
+collection (by the Persian TeX Group / Vafa Khalighi)
 and provided checks for whether a document was being
 processed with PDF\TeX, or Xe\TeX, or Lua\TeX. This version recodes
 the package and incorporates similar tests from the \textsf{ifetex}
@@ -33,7 +33,7 @@ Yato.
 
 For each \TeX\ variant engine supported two commands are provided:
 \begin{itemize}
-\item 
+\item
  a conditional, \verb|\iffootex| that is true if the \textsf(footex)
 engine (or a compatible extension) is being used.
 
@@ -123,23 +123,7 @@ true for Lua\TeX\ and Xe\TeX, allowing constructs such as
 True if Texpad\TeX\ is in use. Please note that Texpad\TeX\ can run in two
 modes, one which uses Unicode and native fonts internally (similar to
 Xe\TeX\ and Lua\TeX), and one which uses 8-bit codepages internally (similar to
-PDF\TeX). These modes can be further distinguished with
-\cs{iftexpadtexunicode} and \cs{iftexpadtexeightbit} respectively, allowing for
-constructs such as
-\begin{verbatim}
-\iftexpadtexunicode
-  \usepackage{fontspec}
-  \setmainfont{Times}
-\else
-  \usepackage{times}
-\fi
-\end{verbatim}
-\begin{description}
-\item[\cs{iftexpadtexunicode}, \cs{ifTexpadTeXUnicode}]
-True if Texpad\TeX\ is running in Unicode mode.
-\item[\cs{iftexpadtexeightbit}, \cs{ifTexpadTeXEightBit}]
-True if Texpad\TeX\ is running in 8-bit mode.
-\end{description}
+PDF\TeX). This can be determined using \cs{iftutex}.
 
 \end{description}
 
@@ -161,8 +145,6 @@ with a suitable engine, and stops with an error message if not.
 \item[\cs{RequireAlephTeX}]
 \item[\cs{RequireTUTeX}]
 \item[\cs{RequireTexpadTeX}]
-\item[\cs{RequireTexpadTeXUnicode}]
-\item[\cs{RequireTexpadTeXEightBit}]
 \end{description}
 
 


### PR DESCRIPTION
We've been developing TexpadTeX as an integrated typesetter for Texpad for some time now. It was forked from KerTeX originally, but since we have rewritten the original eTeX WEB source in C++, with a new Pascal runtime, and extended it to support a number of more modern packages, such as `fontspec` and `pgf`. We have also patched a number of standard LaTeX packages such that they backend correctly onto TexpadTeX.

We'd like to merge a number of our package changes upstream now, so we don't need to rebase the changes every time the package changes. As a first step we are hoping to add an `iftexpadtex` macro into the new `iftex` package. If that were to be in place we could approach individual package authors with patches to make them compatible with TexpadTeX.

This patch uses the `TexpadTeXMode` command, which will be in the next version of TexpadTeX, released with the iOS and macOS apps, but it won't work with the currently released version. We can send a beta of the current version if required for testing. Also, as TexpadTeX uses an Apple PDF library, we don't have a binary right now that could be used on any platform for command line testing. We are working on a common PDF library, after which our intention is to create a binary download of TexpadTeX with the same interface as other TeXs.
