### PR TITLE
Add LuaMetaTeX test

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The package (which works with plain TeX as well as LaTeX) has tests
 for:
 
 eTeX, PDFTeX, XeTeX, LuaTeX, LuaHBTeX, pTeX, upTeX, pTeX-ng, VTeX, Aleph,
-TexpadTeX, HiTeX.
+TexpadTeX, HiTeX, LuaMetaTeX.
 
 
 In addition, an \iftutex test is true for XeTeX and LuaTeX, and

--- a/iftex.sty
+++ b/iftex.sty
@@ -80,6 +80,7 @@
 \IFTEX@protected\def\RequireXeTeX{\IFTEX@Require\ifxetex{XeTeX}\fi}
 \IFTEX@protected\def\RequireLuaTeX{\IFTEX@Require\ifluatex{LuaTeX}\fi}
 \IFTEX@protected\def\RequireLuaHBTeX{\IFTEX@Require\ifluahbtex{LuaHBTeX}\fi}
+\IFTEX@protected\def\RequireLuaMetaTeX{\IFTEX@Require\ifluahbtex{LuaMetaTeX}\fi}
 \IFTEX@protected\def\RequirepTeX{\IFTEX@Require\ifptex{pTeX}\fi}
 \IFTEX@protected\def\RequireupTeX{\IFTEX@Require\ifuptex{upTeX}\fi}
 \IFTEX@protected\def\RequirepTeXng{\IFTEX@Require\ifptexng{pTeX-ng}\fi}
@@ -130,7 +131,7 @@
 \IFTEX@let{XeTeX}{xetex}
 
 
-% luatex (including luahbtex)
+% luatex (including luahbtex and luametatex)
 \begingroup\expandafter\expandafter\expandafter\endgroup
 \expandafter\ifx\csname directlua\endcsname\relax
   \IFTEX@let{luatex}{false}
@@ -155,6 +156,20 @@
 
 \fi
 \IFTEX@let{LuaHBTeX}{luahbtex}
+
+
+% luametatex
+\begingroup\expandafter\expandafter\expandafter\endgroup
+\expandafter\ifx\csname directlua\endcsname\relax
+  \IFTEX@let{luametatex}{false}
+\else
+  \ifnum\luatexversion<200
+    \IFTEX@let{luametatex}{false}
+  \else
+    \IFTEX@let{luametatex}{true}
+  \fi
+\fi
+\IFTEX@let{LuaMetaTeX}{luametatex}
 
 
 % ptex (including all variants)

--- a/iftex.tex
+++ b/iftex.tex
@@ -87,12 +87,14 @@ true for documents processed with both the  \textsf{latex} and
 \item[\cs{ifxetex},     \cs{ifXeTeX}]
 True if Xe\TeX\ is in use.
 \item[\cs{ifluatex},    \cs{ifLuaTeX}]
-True if Lua\TeX\ and extensions such as LuaHB\TeX\ are in use.
+True if Lua\TeX\ and extensions such as LuaHB\TeX\ or LuaMeta\TeX\ are in use.
 \item[\cs{ifluahbtex},  \cs{ifLuaHBTeX}]
 True if the \textsf{luaharftex} Lua module is available.
 This will be true in \textsf{luahbtex} and may be true in
 \textsf{luatex} if a binary Lua \textsf{luaharftex} module has been
 compiled and is available in Lua's search path.
+\item[\cs{ifluametatex},  \cs{ifLuaMetaTeX}]
+True if LuaMeta\TeX\ is in use.
 \item[\cs{ifptex},      \cs{ifpTeX}]
 True if any of the p\TeX\ variants are in use.
 \item[\cs{ifuptex},     \cs{ifupTeX}]
@@ -139,6 +141,7 @@ with a suitable engine, and stops with an error message if not.
 \item[\cs{RequireXeTeX}]
 \item[\cs{RequireLuaTeX}]
 \item[\cs{RequireLuaHBTeX}]
+\item[\cs{RequireLuaMetaTeX}]
 \item[\cs{RequirepTeX}]
 \item[\cs{RequireupTeX}]
 \item[\cs{RequirepTeXng}]


### PR DESCRIPTION
Adding separate checks for LuaMetaTeX. LuaMetaTeX still also gets detected as LuaTeX since they behave similar most of the time.